### PR TITLE
Fix port mapping to allow access to the app

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,6 @@ services:
         volumes:
             - ./src:/app/src
         ports:
-            - "8080:8080"
+            - "3000:3000"
             - "8181:8181"
         command: npm run dev


### PR DESCRIPTION
Da forma atual, a porta 8080 do container é mapeada para a 8080 do host, porém, como o app sobe pela porta 3000, nada fica disponível para o host.

Com essa alteração, será possível acessar o app via `localhost:3000`

Closes #2 